### PR TITLE
Special case the base coin, xDai, and filter from wallet

### DIFF
--- a/src/components/ModalAccount.vue
+++ b/src/components/ModalAccount.vue
@@ -134,7 +134,7 @@ export default defineComponent({
             const { balances } = store.state.account;
             return Object.keys(balances)
                 .map(assetAddress => {
-                    const assetMetadata = metadata[assetAddress];
+                    const assetMetadata = assetAddress === 'xdai' ? "" : metadata[assetAddress];
                     const { address, name, symbol, decimals } = assetMetadata;
                     const balance = balances[address] || '0';
                     const balanceNumber = new BigNumber(balance);
@@ -149,7 +149,8 @@ export default defineComponent({
                         amount,
                     };
                 }).
-                filter(balance => balance.amount !== '');
+                filter(balance => balance.amount !== '').
+                filter(address => address.address !== undefined);
         });
 
         function copyAddress(): void {


### PR DESCRIPTION
The wallet fails to open since it tries to read values from the base XDAI coin as if it was any ERC20 coin.
This change filters out the base XDAI coin so only tradable ERC20 coins are listed