### PR TITLE
Added support for Avalanche, Fantom, Optimism and Polygon

### DIFF
--- a/src/api/ethereum.ts
+++ b/src/api/ethereum.ts
@@ -67,6 +67,18 @@ export default class Ethereum {
             case 'alfajores':
               balances.celo = data[2 * assetCount].toString();
               break;
+            case 'avalanche':
+              balances.wavax = data[2 * assetCount].toString();
+              break;
+            case 'fantom':
+              balances.wftm = data[2 * assetCount].toString();
+              break;
+            case 'optimism':
+              balances.weth = data[2 * assetCount].toString();
+              break;
+            case 'polygon':
+              balances.wmatic = data[2 * assetCount].toString();
+              break;
             case 'ethereum':
             default:
               balances.ether = data[2 * assetCount].toString();

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -106,6 +106,82 @@ export default defineComponent({
                     id: 1,
                 }, console.log);
                 break;
+            case "avalanche":
+                window.ethereum.request({
+                    method: 'wallet_addEthereumChain',
+                    params: [
+                        {
+                            'chainId': '43114',
+                            'chainName': 'Avalanche',
+                            'rpcUrls': ['https://api.avax.network/ext/bc/C/rpc'],
+                            'nativeCurrency': {
+                                'name': 'Avax',
+                                'symbol': 'AVAX',
+                                'decimals': 18,
+                            },
+                            'blockExplorerUrls': ['https://snowtrace.io/'],
+                        },
+                    ],
+                    id: 1,
+                }, console.log);
+                break;
+            case "fantom":
+                window.ethereum.request({
+                    method: 'wallet_addEthereumChain',
+                    params: [
+                        {
+                            'chainId': '250',
+                            'chainName': 'Fantom',
+                            'rpcUrls': ['https://rpc.ftm.tools/'],
+                            'nativeCurrency': {
+                                'name': 'Ftm',
+                                'symbol': 'FTM',
+                                'decimals': 18,
+                            },
+                            'blockExplorerUrls': ['https://ftmscan.com/'],
+                        },
+                    ],
+                    id: 1,
+                }, console.log);
+                break;
+            case "optimism":
+                window.ethereum.request({
+                    method: 'wallet_addEthereumChain',
+                    params: [
+                        {
+                            'chainId': '10',
+                            'chainName': 'Optimism',
+                            'rpcUrls': ['https://mainnet.optimism.io'],
+                            'nativeCurrency': {
+                                'name': 'Ether',
+                                'symbol': 'ETH',
+                                'decimals': 18,
+                            },
+                            'blockExplorerUrls': ['https://optimistic.etherscan.io'],
+                        },
+                    ],
+                    id: 1,
+                }, console.log);
+                break;
+            case "polygon":
+                window.ethereum.request({
+                    method: 'wallet_addEthereumChain',
+                    params: [
+                        {
+                            'chainId': '137',
+                            'chainName': 'Polygon',
+                            'rpcUrls': ['https://polygon-rpc.com/'],
+                            'nativeCurrency': {
+                                'name': 'Matic',
+                                'symbol': 'MATIC',
+                                'decimals': 18,
+                            },
+                            'blockExplorerUrls': ['https://polygonscan.com/'],
+                        },
+                    ],
+                    id: 1,
+                }, console.log);
+                break;
             case "alfajores":
                 window.ethereum.request({
                     method: 'wallet_addEthereumChain',

--- a/src/components/swap/Button.vue
+++ b/src/components/swap/Button.vue
@@ -202,6 +202,14 @@ export default defineComponent({
                 case 'celo':
                 case 'alfajores':
                     break;
+                case 'avalanche':
+                    break;
+                case 'fantom':
+                    break;
+                case 'optimism':
+                    break;
+                case 'polygon':
+                    break;
                 case 'ethereum':
                 default:
                     if (assetIn === ETH_KEY && assetOut === config.addresses.weth) {

--- a/src/config/avalanche.json
+++ b/src/config/avalanche.json
@@ -1,0 +1,31 @@
+{
+  "network": "avalanche",
+  "eth_key": "avalanche",
+  "chainId": 43114,
+  "defaultPrecision": 6,
+  "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
+  "rpcUrl": "https://api.avax.network/ext/bc/C/rpc",
+  "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-avalanche",
+  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-avalanche/pools",
+  "addresses": {
+    "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
+    "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",
+    "dsProxyRegistry": "0xbC46037Ac210f9Ca1c2803a74e455d251D966BD7",
+    "exchangeProxy": "0x7EbE42906a5F1DD96E47E7152102A6aA0A0d2459",
+    "wavax": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+    "multicall": "0xB3cb9Ec46bEDB9A85b79fBf52339de238a8e7f3e"
+  },
+  "connectors": {
+    "injected": {},
+    "walletconnect": {
+      "id": "walletconnect",
+      "options": {
+        "rpc": {
+          "43114": "https://api.avax.network/ext/bc/C/rpc"
+        },
+        "chainId": 43114
+      }
+    }
+  }
+}
+

--- a/src/config/fantom.json
+++ b/src/config/fantom.json
@@ -1,0 +1,31 @@
+{
+  "network": "fantom",
+  "eth_key": "fantom",
+  "chainId": 250,
+  "defaultPrecision": 6,
+  "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
+  "rpcUrl": "https://rpc.ftm.tools/",
+  "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-fantom",
+  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-fantom/pools",
+  "addresses": {
+    "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
+    "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",
+    "dsProxyRegistry": "0xbC46037Ac210f9Ca1c2803a74e455d251D966BD7",
+    "exchangeProxy": "0x7EbE42906a5F1DD96E47E7152102A6aA0A0d2459",
+    "wftm": "0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83",
+    "multicall": "0xB3cb9Ec46bEDB9A85b79fBf52339de238a8e7f3e"
+  },
+  "connectors": {
+    "injected": {},
+    "walletconnect": {
+      "id": "walletconnect",
+      "options": {
+        "rpc": {
+          "250": "https://rpc.ftm.tools/"
+        },
+        "chainId": 250
+      }
+    }
+  }
+}
+

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,10 @@ import sokol from './sokol.json';
 import xdai from './xdai.json';
 import alfajores from './alfajores.json';
 import celo from './celo.json';
+import avalanche from './avalanche.json';
+import fantom from './fantom.json';
+import optimism from './optimism.json';
+import polygon from './polygon.json';
 
 interface Connector {
     id: string;
@@ -36,6 +40,10 @@ interface Config {
         weth: string;
         wxdai: string;
         celo: string;
+        avalanche: string;
+        fantom: string;
+        optimism: string;
+        polygon: string;
         wspoa: string;
         multicall: string;
     };
@@ -49,6 +57,10 @@ const configs = {
         untrusted: [],
         ...homestead,
     },
+    10:{
+        untrusted: [],
+        ...optimism,
+    },
     42:{
         untrusted: [],
         ...kovan,
@@ -61,6 +73,14 @@ const configs = {
         untrusted: [],
         ...xdai,
     },
+    137:{
+        untrusted: [],
+        ...polygon,
+    },
+    250:{
+        untrusted: [],
+        ...fantom,
+    },
     44787:{
         untrusted: [],
         ...alfajores,
@@ -68,6 +88,10 @@ const configs = {
     42220:{
         untrusted: [],
         ...celo,
+    },
+    43114:{
+        untrusted: [],
+        ...avalanche,
     },
 };
 // eslint-disable-next-line no-undef

--- a/src/config/optimism.json
+++ b/src/config/optimism.json
@@ -1,0 +1,30 @@
+{
+  "network": "optimism",
+  "eth_key": "optimism",
+  "chainId": 10,
+  "defaultPrecision": 6,
+  "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
+  "rpcUrl": "https://mainnet.optimism.io",
+  "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-optimism",
+  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-optimism/pools",
+  "addresses": {
+    "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
+    "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",
+    "dsProxyRegistry": "0xbC46037Ac210f9Ca1c2803a74e455d251D966BD7",
+    "exchangeProxy": "0x7EbE42906a5F1DD96E47E7152102A6aA0A0d2459",
+    "weth": "0x4200000000000000000000000000000000000006",
+    "multicall": "0xB3cb9Ec46bEDB9A85b79fBf52339de238a8e7f3e"
+  },
+  "connectors": {
+    "injected": {},
+    "walletconnect": {
+      "id": "walletconnect",
+      "options": {
+        "rpc": {
+          "10": "https://mainnet.optimism.io"
+        },
+        "chainId": 10
+      }
+    }
+  }
+}

--- a/src/config/polygon.json
+++ b/src/config/polygon.json
@@ -1,0 +1,31 @@
+{
+  "network": "polygon",
+  "eth_key": "polygon",
+  "chainId": 137,
+  "defaultPrecision": 6,
+  "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
+  "rpcUrl": "https://polygon-rpc.com/",
+  "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-polygon",
+  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-polygon/pools",
+  "addresses": {
+    "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
+    "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",
+    "dsProxyRegistry": "0xbC46037Ac210f9Ca1c2803a74e455d251D966BD7",
+    "exchangeProxy": "0x7EbE42906a5F1DD96E47E7152102A6aA0A0d2459",
+    "wmatic": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+    "multicall": "0xB3cb9Ec46bEDB9A85b79fBf52339de238a8e7f3e"
+  },
+  "connectors": {
+    "injected": {},
+    "walletconnect": {
+      "id": "walletconnect",
+      "options": {
+        "rpc": {
+          "137": "https://polygon-rpc.com/"
+        },
+        "chainId": 137
+      }
+    }
+  }
+}
+

--- a/src/pages/Swap.vue
+++ b/src/pages/Swap.vue
@@ -220,6 +220,18 @@ export default defineComponent({
                 case 'alfajores':
                     assetOutAddress = assetOutAddressInput.value;
                     break;
+                case 'avalanche':
+                    assetOutAddress = assetOutAddressInput.value;
+                    break;
+                case 'fantom':
+                    assetOutAddress = assetOutAddressInput.value;
+                    break;
+                case 'optimism':
+                    assetOutAddress = assetOutAddressInput.value;
+                    break;
+                case 'polygon':
+                    assetOutAddress = assetOutAddressInput.value;
+                    break;
                 case 'ethereum':
                 default:
                     assetOutAddress = assetOutAddressInput.value === ETH_KEY
@@ -299,6 +311,14 @@ export default defineComponent({
                 case 'celo':
                 case 'alfajores':
                     break;
+                case 'avalanche':
+                    break;
+                case 'fantom':
+                    break;
+                case 'optimism':
+                    break;
+                case 'polygon':
+                    break;
                 case 'ethereum':
                 default:
                     if (assetInAddress === ETH_KEY) {
@@ -374,6 +394,22 @@ export default defineComponent({
                 assetInAddress = assetInAddressInput.value;
                 assetOutAddress = assetOutAddressInput.value;
                 break;
+            case 'avalanche':
+                assetInAddress = assetInAddressInput.value;
+                assetOutAddress = assetOutAddressInput.value;
+                break;
+            case 'fantom':
+                assetInAddress = assetInAddressInput.value;
+                assetOutAddress = assetOutAddressInput.value;
+                break;
+            case 'optimism':
+                assetInAddress = assetInAddressInput.value;
+                assetOutAddress = assetOutAddressInput.value;
+                break;
+            case 'polygon':
+                assetInAddress = assetInAddressInput.value;
+                assetOutAddress = assetOutAddressInput.value;
+                break;
             case 'ethereum':
             default:
                 assetInAddress = assetInAddressInput.value === ETH_KEY
@@ -443,6 +479,22 @@ export default defineComponent({
                 break;
             case 'celo':
             case 'alfajores':
+                assetInAddress = assetInAddressInput.value;
+                assetOutAddress = assetOutAddressInput.value;
+                break;
+            case 'avalanche':
+                assetInAddress = assetInAddressInput.value;
+                assetOutAddress = assetOutAddressInput.value;
+                break;
+            case 'fantom':
+                assetInAddress = assetInAddressInput.value;
+                assetOutAddress = assetOutAddressInput.value;
+                break;
+            case 'optimism':
+                assetInAddress = assetInAddressInput.value;
+                assetOutAddress = assetOutAddressInput.value;
+                break;
+            case 'polygon':
                 assetInAddress = assetInAddressInput.value;
                 assetOutAddress = assetOutAddressInput.value;
                 break;
@@ -617,6 +669,14 @@ export default defineComponent({
                 break;
             case 'celo':
             case 'alfajores':
+                break;
+            case 'avalanche':
+                break;
+            case 'fantom':
+                break;
+            case 'optimism':
+                break;
+            case 'polygon':
                 break;
             case 'ethereum':
             default:

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -54,11 +54,15 @@ export function getEtherscanLink(txHash: string): string {
     const chainId = config.chainId;
     const urlMap = {
         1: 'https://etherscan.io/tx',
+        10: 'https://optimism.symmetric.exchange/tx',
         42: 'https://kovan.etherscan.io/tx',
         77: 'https://blockscout.com/poa/sokol/tx',
         100: 'https://blockscout.com/xdai/mainnet/tx',
-        44787: 'https://alfajores-blockscout.celo-testnet.org/tx',
+        137: 'https://polygonscan.com/tx',
+        250: 'https://fantom.symmetric.exchange/tx',
         42220: 'https://explorer.celo.org/tx',
+        43114: 'https://snowtrace.io/tx',
+        44787: 'https://alfajores-blockscout.celo-testnet.org/tx',
     };
     const url = urlMap[chainId];
     const link = `${url}/${txHash}`;
@@ -69,11 +73,15 @@ export function getAccountLink(address: string): string {
     const chainId = config.chainId;
     const urlMap = {
         1: 'https://etherscan.io/address',
+        10: 'https://optimism.symmetric.exchange/address',
         42: 'https://kovan.etherscan.io/address',
         77: 'https://blockscout.com/poa/sokol/address',
         100: 'https://blockscout.com/xdai/mainnet/address',
-        44787: 'https://alfajores-blockscout.celo-testnet.org/address',
+        137: 'https://polygonscan.com/address',
+        250: 'https://fantom.symmetric.exchange/address',
         42220: 'https://explorer.celo.org/address',
+        43114: 'https://snowtrace.io/tx',
+        44787: 'https://alfajores-blockscout.celo-testnet.org/address',
     };
     const url = urlMap[chainId];
     const link = `${url}/${address}`;
@@ -84,11 +92,15 @@ export function getPoolLink(pool: string): string {
     const chainId = config.chainId;
     const prefixMap = {
         1: '',
+        10: 'optimism',
         42: 'kovan.',
         77: 'sokol.',
         100: 'xdai.',
-        44787: 'alfajores.',
+        137: 'polygon.',
+        250: 'fantom,',
         42220: 'celo',
+        43114: 'avalanche',
+        44787: 'alfajores.',
     };
     const prefix = prefixMap[chainId];
     const link = `https://${prefix}-pools.symmetric.exchange/#/pool/${pool}`;

--- a/src/utils/list.ts
+++ b/src/utils/list.ts
@@ -94,6 +94,10 @@ export function getAssetsFromTokenlist(chainId: number, list: TokenList): Record
             break;
         case 'celo':
         case 'alfajores':
+        case 'avalanche':
+        case 'fantom':
+        case 'optimism':
+        case 'polygon':
             for (const token of list.tokens) {
                 if (token.chainId !== chainId) {
                     continue;

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -19,6 +19,18 @@ switch (config.network) {
     case 'alfajores':
         provider = new JsonRpcProvider(config.rpcUrl, 44787);
         break;
+    case 'avalanche':
+        provider = new JsonRpcProvider(config.rpcUrl, 43114);
+        break;
+    case 'fantom':
+        provider = new JsonRpcProvider(config.rpcUrl, 250);
+        break;
+    case 'optimism':
+        provider = new JsonRpcProvider(config.rpcUrl, 10);
+        break;
+    case 'polygon':
+        provider = new JsonRpcProvider(config.rpcUrl, 137);
+        break;
     case 'kovan':
         provider = new JsonRpcProvider(config.rpcUrl, 42);
         break;

--- a/src/web3/helper.ts
+++ b/src/web3/helper.ts
@@ -62,6 +62,14 @@ export default class Helper {
             case 'celo':
             case 'alfajores':
                 break;
+            case 'avalanche':
+                break;
+            case 'fantom':
+                break;
+            case 'optimism':
+                break;
+            case 'polygon':
+                break;
             case 'ethereum':
             default:
                 const wethContract = new Contract(config.addresses.weth, WethAbi, provider.getSigner());
@@ -109,6 +117,14 @@ export default class Helper {
                 }
             case 'celo':
             case 'alfajores':
+                break;
+            case 'avalanche':
+                break;
+            case 'fantom':
+                break;
+            case 'optimism':
+                break;
+            case 'polygon':
                 break;
             case 'ethereum':
             default:


### PR DESCRIPTION
- Refactored utils.ts code to simplify and better support multiple networks
- Added support for Avalanche
- Added support for Fantom
- Added support for Optimism
- Added support for Polygon
- Disabled Subgraph lookup for new networks and new SYMM price feeds in UI until they exist

Let's get this done, looking forward to seeing this fly on these networks.

Address on Ethereum, xDai and Celo: 0x56a03b6359d31e034a4a09158bA0a93a1C57E7bc