### PR TITLE
Replaced Fleek with a local file backup

### DIFF
--- a/src/config/alfajores.json
+++ b/src/config/alfajores.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://alfajores-forno.celo-testnet.org",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/cent-swap-alfajores",
-  "subgraphBackupUrl": "https://switch1983-team-bucket.storage.fleek.co/cent-exchange-alfajores/pools",
+  "subgraphBackupUrl": "https://alfajores.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x07Fa70d4560663E64b44a217AD40a926Dc5BdA5c",
     "bActions": "0x05d52ee5455FDe856f7932B3ec58060484201cD6",

--- a/src/config/avalanche.json
+++ b/src/config/avalanche.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://api.avax.network/ext/bc/C/rpc",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-avalanche",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-avalanche/pools",
+  "subgraphBackupUrl": "https://avalanche.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/celo.json
+++ b/src/config/celo.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://forno.celo.org",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetricv1celo",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/b1fabc47-baed-4431-ad28-2914a0ff0dbf-bucket/symmetric-celo/pools",
+  "subgraphBackupUrl": "https://celo.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/fantom-testnet.json
+++ b/src/config/fantom-testnet.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://rpc.testnet.fantom.network/",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-fantom-testnet",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-fantom-testnet/pools",
+  "subgraphBackupUrl": "https://fantom-testnet.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/fantom.json
+++ b/src/config/fantom.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://rpc.ftm.tools/",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-fantom",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-fantom/pools",
+  "subgraphBackupUrl": "https://fantom.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/fuji.json
+++ b/src/config/fuji.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://api.avax-test.network/ext/bc/C/rpc",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-fuji",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-fuji/pools",
+  "subgraphBackupUrl": "https://fuji.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/kovan.json
+++ b/src/config/kovan.json
@@ -6,7 +6,7 @@
     "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
     "rpcUrl": "https://kovan.infura.io/v3/e68cb3352f7d4fb7848c4650917e4422",
     "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/cent-swap-kovan",
-    "subgraphBackupUrl": "https://switch1983-team-bucket.storage.fleek.co/cent-exchange-kovan/pools",
+    "subgraphBackupUrl": "https://kovan.symmetric.exchange/pooldata.json",
     "addresses": {
         "bFactory": "0xf5fc5042d8424619BB318bAeDd0f0F1A591f2a3A",
         "bActions": "0x57562A82F2Fd9Eb21E7edf87b62e8353027f280E",

--- a/src/config/optimism-kovan.json
+++ b/src/config/optimism-kovan.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://kovan.optimism.io",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-optimism-kovan",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-optimism-kovan/pools",
+  "subgraphBackupUrl": "https://optimism-kovan.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/optimism.json
+++ b/src/config/optimism.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://mainnet.optimism.io",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-optimism",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-optimism/pools",
+  "subgraphBackupUrl": "https://optimism.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/polygon-mumbai.json
+++ b/src/config/polygon-mumbai.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://rpc-mumbai.maticvigil.com/",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-mumbai",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-mumbai/pools",
+  "subgraphBackupUrl": "https://polygon-mumbai.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/polygon.json
+++ b/src/config/polygon.json
@@ -6,7 +6,7 @@
   "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
   "rpcUrl": "https://polygon-rpc.com/",
   "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-polygon",
-  "subgraphBackupUrl": "https://storageapi.fleek.co/switch1983-team-bucket/cent-exchange-polygon/pools",
+  "subgraphBackupUrl": "https://polygon.symmetric.exchange/pooldata.json",
   "addresses": {
     "bFactory": "0x6C2e59C3cCB1d81c0eC9Fb9d4d6a3CC3488Fd71c",
     "bActions": "0xBe04ae09b9e41b8828b8866280bF882b42576b4e",

--- a/src/config/sokol.json
+++ b/src/config/sokol.json
@@ -6,7 +6,7 @@
     "infuraKey": "e68cb3352f7d4fb7848c4650917e4422",
     "rpcUrl": "https://sokol.poa.network",
     "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/cent-swap-sokol",
-    "subgraphBackupUrl": "https://switch1983-team-bucket.storage.fleek.co/cent-exchange-sokol/pools",
+    "subgraphBackupUrl": "https://sokol.symmetric.exchange/pooldata.json",
     "addresses": {
         "bFactory": "0x3B4261a0A617a01ff7994bD15896ab1d384baABF",
         "bActions": "0x2d9837C9ca00aB3A784fBfa6280539BA57Ab0233",

--- a/src/config/xdai.json
+++ b/src/config/xdai.json
@@ -6,7 +6,7 @@
     "infuraKey": "92df310bb7f5c38db174697344e5be533a420d34",
     "rpcUrl": "https://rpc.xdaichain.com/",
     "subgraphUrl": "https://api.thegraph.com/subgraphs/name/centfinance/symmetric-xdai",
-    "subgraphBackupUrl": "https://storageapi.fleek.co/b1fabc47-baed-4431-ad28-2914a0ff0dbf-bucket/symmetric-xdai/pools",
+    "subgraphBackupUrl": "https://xdai.symmetric.exchange/pooldata.json",
     "addresses": {
       "bFactory": "0x9B4214FD41cD24347A25122AC7bb6B479BED72Ac",
       "bActions": "0x88602D7ef1a3026daF96729938d6184cDAbbED95",


### PR DESCRIPTION
Fleek has been unreliable so a version of the background services now runs directly on the Symmetric server, copying the pool files into the Exchange project. Previously, these files were stored on IPFS via Fleek.

For the time being we will continue to run the background services that also write to IPFS as a backup but once we are comfortable with the new approach we will shut the background services server down and just use the versions that work directly with the exchange portal. 

This PR is just a change to the config files to get the pools file from the Exchange website, instead of from Fleek. We need to test this in production to ensure there are no CORS or other issues.